### PR TITLE
Add Kali Linux support

### DIFF
--- a/DIFF_20250709_055204.md
+++ b/DIFF_20250709_055204.md
@@ -1,0 +1,2 @@
+Changes made on 2025-07-09 05:52 UTC:
+- Added Kali Linux detection to `scripts/install.sh`. The script now maps `kali` to `debian` so installation proceeds on Kali Linux.

--- a/RECOMMENDATIONS_20250709_055204.md
+++ b/RECOMMENDATIONS_20250709_055204.md
@@ -1,0 +1,3 @@
+Recommendations logged on 2025-07-09 05:52 UTC:
+- Document Kali Linux compatibility in the installation instructions.
+- Consider creating a dedicated variable for base OS type to avoid altering `OS_TYPE` when mapping derivative distributions.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,6 +116,11 @@ if [ "$OS_TYPE" = "zorin" ]; then
     OS_TYPE="ubuntu"
 fi
 
+# Check if the OS is Kali Linux, if so, change it to debian
+if [ "$OS_TYPE" = "kali" ]; then
+    OS_TYPE="debian"
+fi
+
 if [ "$OS_TYPE" = "arch" ] || [ "$OS_TYPE" = "archarm" ]; then
     OS_VERSION="rolling"
 else


### PR DESCRIPTION
## Summary
- allow Kali Linux installs by mapping OS type to Debian
- document the change and recommendations in timestamped files

## Testing
- `bash -n scripts/install.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e02ea5ae4832ab8d512fb77880193

## Summary by Sourcery

Enable Kali Linux support by mapping 'kali' to 'debian' in the install script and record the change with timestamped documentation files

New Features:
- Allow installation on Kali Linux by mapping 'kali' to 'debian' in the install script

Documentation:
- Add timestamped recommendation and diff files documenting Kali Linux compatibility changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kali Linux during installation by treating it as Debian, enabling successful installation on Kali Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->